### PR TITLE
fix(quarkus): consume RUN_TIME config via recorder and fix quarkus.orqueio config prefix

### DIFF
--- a/quarkus-extension/README.md
+++ b/quarkus-extension/README.md
@@ -26,25 +26,25 @@ can look like the following:
 
 ```properties
 # process engine configuration
-quarkus.orqueio..generic-config.cmmn-enabled=false
-quarkus.orqueio..generic-config.dmn-enabled=false
-quarkus.orqueio..generic-config.history=none
+quarkus.orqueio.generic-config.cmmn-enabled=false
+quarkus.orqueio.generic-config.dmn-enabled=false
+quarkus.orqueio.generic-config.history=none
 
 # job executor configuration
-quarkus.orqueio..job-executor.thread-pool.max-pool-size=12
-quarkus.orqueio..job-executor.thread-pool.queue-size=5
-quarkus.orqueio..job-executor.generic-config.max-jobs-per-acquisition=5
-quarkus.orqueio..job-executor.generic-config.lock-time-in-millis=500000
-quarkus.orqueio..job-executor.generic-config.wait-time-in-millis=7000
-quarkus.orqueio..job-executor.generic-config.max-wait=65000
-quarkus.orqueio..job-executor.generic-config.backoff-time-in-millis=5
+quarkus.orqueio.job-executor.thread-pool.max-pool-size=12
+quarkus.orqueio.job-executor.thread-pool.queue-size=5
+quarkus.orqueio.job-executor.generic-config.max-jobs-per-acquisition=5
+quarkus.orqueio.job-executor.generic-config.lock-time-in-millis=500000
+quarkus.orqueio.job-executor.generic-config.wait-time-in-millis=7000
+quarkus.orqueio.job-executor.generic-config.max-wait=65000
+quarkus.orqueio.job-executor.generic-config.backoff-time-in-millis=5
 
 # custom data source configuration and selection
 quarkus.datasource.my-datasource.db-kind=h2
 quarkus.datasource.my-datasource.username=orqueio.
 quarkus.datasource.my-datasource.password=orqueio.
 quarkus.datasource.my-datasource.jdbc.url=jdbc:h2:mem:camunda.;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
-quarkus.orqueio..datasource=my-datasource
+quarkus.orqueio.datasource=my-datasource
 ```
 
 ### Local Build

--- a/quarkus-extension/engine/deployment/src/main/java/io/orqueio/bpm/quarkus/engine/extension/deployment/impl/OrqueioEngineProcessor.java
+++ b/quarkus-extension/engine/deployment/src/main/java/io/orqueio/bpm/quarkus/engine/extension/deployment/impl/OrqueioEngineProcessor.java
@@ -40,7 +40,6 @@ import io.orqueio.bpm.engine.cdi.impl.ProcessVariableMap;
 import io.orqueio.bpm.engine.cdi.impl.context.DefaultContextAssociationManager;
 import io.orqueio.bpm.engine.cdi.impl.context.RequestScopedAssociation;
 import io.orqueio.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import io.orqueio.bpm.quarkus.engine.extension.OrqueioEngineConfig;
 import io.orqueio.bpm.quarkus.engine.extension.QuarkusProcessEngineConfiguration;
 import io.orqueio.bpm.quarkus.engine.extension.impl.OrqueioEngineRecorder;
 import io.orqueio.bpm.quarkus.engine.extension.impl.InjectableBusinessProcessContext;
@@ -96,13 +95,12 @@ public class OrqueioEngineProcessor {
   @Record(RUNTIME_INIT)
   protected void processEngineConfiguration(OrqueioEngineRecorder recorder,
                                             BeanContainerBuildItem beanContainerBuildItem,
-                                            OrqueioEngineConfig orqueioEngineConfig,
                                             BuildProducer<ProcessEngineConfigurationBuildItem> configurationProducer) {
 
     BeanContainer beanContainer = beanContainerBuildItem.getValue();
     recorder.configureProcessEngineCdiBeans(beanContainer);
     RuntimeValue<ProcessEngineConfigurationImpl> processEngineConfiguration =
-        recorder.createProcessEngineConfiguration(beanContainer, orqueioEngineConfig);
+        recorder.createProcessEngineConfiguration(beanContainer);
     configurationProducer.produce(new ProcessEngineConfigurationBuildItem(processEngineConfiguration));
   }
 

--- a/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/config/OrqueioEngineConfigFileTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/config/OrqueioEngineConfigFileTest.java
@@ -70,7 +70,7 @@ public class OrqueioEngineConfigFileTest {
     assertThat(config.jobExecutor().threadPool().maxPoolSize()).isEqualTo(12);
     assertThat(config.jobExecutor().threadPool().queueSize()).isEqualTo(5);
     // assert correct datasource
-    assertThat(config.datasource()).hasValue("orqueio.");
+    assertThat(config.datasource()).hasValue("orqueio");
     assertThat(configuration.getDataSource().getConnection()).asString().contains("h2:mem:camunda.");
   }
 }

--- a/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/config/OrqueioEngineProgrammaticAndConfigFileTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/config/OrqueioEngineProgrammaticAndConfigFileTest.java
@@ -91,7 +91,7 @@ public class OrqueioEngineProgrammaticAndConfigFileTest {
     assertThat(config.jobExecutor().threadPool().maxPoolSize()).isEqualTo(12);
     assertThat(config.jobExecutor().threadPool().queueSize()).isEqualTo(5);
     // assert correct datasource
-    assertThat(config.datasource()).hasValue("orqueio.");
+    assertThat(config.datasource()).hasValue("orqueio");
     assertThat(configuration.getDataSource().getConnection()).asString().contains("h2:mem:camunda.");
   }
 }

--- a/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/lookup/ProgrammaticBeanLookupTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/lookup/ProgrammaticBeanLookupTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This test is copied and adjusted from the engine-cdi module to work with Quarkus.
- * See https://jira.orqueio..com/browse/CAM-13747 for the reasoning.
+ * See https://jira.orqueio.com/browse/CAM-13747 for the reasoning.
  */
 public class ProgrammaticBeanLookupTest {
 

--- a/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/persistence/conf/ChooseDatasourceConfigurationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/persistence/conf/ChooseDatasourceConfigurationTest.java
@@ -35,7 +35,7 @@ public class ChooseDatasourceConfigurationTest {
   @RegisterExtension
   static QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
       .withConfigurationResource("io/orqueio/bpm/quarkus/engine/test/persistence/conf/multiple-datasources-application.properties")
-      .overrideConfigKey("quarkus.orqueio..datasource", "secondary")
+      .overrideConfigKey("quarkus.orqueio.datasource", "secondary")
       .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class));
 
   @Inject

--- a/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/persistence/conf/ChooseNotExistingDatasourceConfigurationTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/persistence/conf/ChooseNotExistingDatasourceConfigurationTest.java
@@ -31,7 +31,7 @@ public class ChooseNotExistingDatasourceConfigurationTest {
   @RegisterExtension
   static QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
       .withConfigurationResource("io/orqueio/bpm/quarkus/engine/test/persistence/conf/multiple-datasources-application.properties")
-      .overrideConfigKey("quarkus.orqueio..datasource", "quaternary")
+      .overrideConfigKey("quarkus.orqueio.datasource", "quaternary")
       .assertException(throwable -> assertThat(throwable)
           .hasMessage("No bean found for required type [interface io.agroal.api.AgroalDataSource] and qualifiers [[@io.quarkus.agroal.DataSource(value=\"quaternary\")]]")
           .isInstanceOf(UnsatisfiedResolutionException.class))

--- a/quarkus-extension/engine/deployment/src/test/resources/application.properties
+++ b/quarkus-extension/engine/deployment/src/test/resources/application.properties
@@ -1,2 +1,2 @@
 quarkus.datasource.jdbc.url=jdbc:h2:mem:camunda.;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
-quarkus.orqueio..generic-config.enforce-history-time-to-live=false
+quarkus.orqueio.generic-config.enforce-history-time-to-live=false

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/config/job-executor-application.properties
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/config/job-executor-application.properties
@@ -1,15 +1,15 @@
-quarkus.orqueio..job-executor.thread-pool.max-pool-size=12
-quarkus.orqueio..job-executor.thread-pool.queue-size=5
+quarkus.orqueio.job-executor.thread-pool.max-pool-size=12
+quarkus.orqueio.job-executor.thread-pool.queue-size=5
 
-quarkus.orqueio..job-executor.generic-config.max-jobs-per-acquisition=5
-quarkus.orqueio..job-executor.generic-config.lock-time-in-millis=500000
-quarkus.orqueio..job-executor.generic-config.wait-time-in-millis=7000
-quarkus.orqueio..job-executor.generic-config.max-wait=65000
-quarkus.orqueio..job-executor.generic-config.backoff-time-in-millis=5
-quarkus.orqueio..job-executor.generic-config.max-backoff=5
-quarkus.orqueio..job-executor.generic-config.backoff-decrease-threshold=120
-quarkus.orqueio..job-executor.generic-config.wait-increase-factor=3
+quarkus.orqueio.job-executor.generic-config.max-jobs-per-acquisition=5
+quarkus.orqueio.job-executor.generic-config.lock-time-in-millis=500000
+quarkus.orqueio.job-executor.generic-config.wait-time-in-millis=7000
+quarkus.orqueio.job-executor.generic-config.max-wait=65000
+quarkus.orqueio.job-executor.generic-config.backoff-time-in-millis=5
+quarkus.orqueio.job-executor.generic-config.max-backoff=5
+quarkus.orqueio.job-executor.generic-config.backoff-decrease-threshold=120
+quarkus.orqueio.job-executor.generic-config.wait-increase-factor=3
 
 quarkus.datasource.jdbc.url=jdbc:h2:mem:camunda.;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
 
-quarkus.orqueio..generic-config.enforce-history-time-to-live=false
+quarkus.orqueio.generic-config.enforce-history-time-to-live=false

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/config/mixed-application.properties
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/config/mixed-application.properties
@@ -1,19 +1,19 @@
-quarkus.orqueio..generic-config.cmmn-enabled=false
-quarkus.orqueio..generic-config.dmn-enabled=false
-quarkus.orqueio..generic-config.history=none
-quarkus.orqueio..generic-config.enforce-history-time-to-live=false
+quarkus.orqueio.generic-config.cmmn-enabled=false
+quarkus.orqueio.generic-config.dmn-enabled=false
+quarkus.orqueio.generic-config.history=none
+quarkus.orqueio.generic-config.enforce-history-time-to-live=false
 
-quarkus.orqueio..job-executor.thread-pool.max-pool-size=12
-quarkus.orqueio..job-executor.thread-pool.queue-size=5
+quarkus.orqueio.job-executor.thread-pool.max-pool-size=12
+quarkus.orqueio.job-executor.thread-pool.queue-size=5
 
-quarkus.orqueio..job-executor.generic-config.max-jobs-per-acquisition=5
-quarkus.orqueio..job-executor.generic-config.lock-time-in-millis=500000
-quarkus.orqueio..job-executor.generic-config.wait-time-in-millis=7000
-quarkus.orqueio..job-executor.generic-config.max-wait=65000
-quarkus.orqueio..job-executor.generic-config.backoff-time-in-millis=5
+quarkus.orqueio.job-executor.generic-config.max-jobs-per-acquisition=5
+quarkus.orqueio.job-executor.generic-config.lock-time-in-millis=500000
+quarkus.orqueio.job-executor.generic-config.wait-time-in-millis=7000
+quarkus.orqueio.job-executor.generic-config.max-wait=65000
+quarkus.orqueio.job-executor.generic-config.backoff-time-in-millis=5
 
-quarkus.datasource.orqueio..db-kind=h2
-quarkus.datasource.orqueio..username=orqueio.
-quarkus.datasource.orqueio..password=orqueio.
-quarkus.datasource.orqueio..jdbc.url=jdbc:h2:mem:camunda.;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
-quarkus.orqueio..datasource=orqueio.
+quarkus.datasource.orqueio.db-kind=h2
+quarkus.datasource.orqueio.username=orqueio.
+quarkus.datasource.orqueio.password=orqueio.
+quarkus.datasource.orqueio.jdbc.url=jdbc:h2:mem:camunda.;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
+quarkus.orqueio.datasource=orqueio

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/config/process-engine-config-application.properties
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/config/process-engine-config-application.properties
@@ -1,6 +1,6 @@
-quarkus.orqueio..generic-config.cmmn-enabled=false
-quarkus.orqueio..generic-config.dmn-enabled=false
-quarkus.orqueio..generic-config.history=none
-quarkus.orqueio..generic-config.enforce-history-time-to-live=false
+quarkus.orqueio.generic-config.cmmn-enabled=false
+quarkus.orqueio.generic-config.dmn-enabled=false
+quarkus.orqueio.generic-config.history=none
+quarkus.orqueio.generic-config.enforce-history-time-to-live=false
 
 quarkus.datasource.jdbc.url=jdbc:h2:mem:camunda.;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE

--- a/quarkus-extension/engine/qa/pom.xml
+++ b/quarkus-extension/engine/qa/pom.xml
@@ -60,7 +60,7 @@
           </dependenciesToScan>
 
           <excludes>
-            <!-- See https://jira.orqueio..com/browse/CAM-13751 -->
+            <!-- See https://jira.orqueio.com/browse/CAM-13751 -->
             <exclude>**/BeanPropertyElTest.java</exclude>
 
             <!-- See ProgrammaticBeanLookupTest in quarkus-extension/engine/deployment module -->

--- a/quarkus-extension/engine/qa/src/test/java/io/orqueio/bpm/engine/cdi/test/CdiProcessEngineTestCase.java
+++ b/quarkus-extension/engine/qa/src/test/java/io/orqueio/bpm/engine/cdi/test/CdiProcessEngineTestCase.java
@@ -104,7 +104,7 @@ public class CdiProcessEngineTestCase {
         bean.destroy();
       } catch (UnsupportedOperationException ignored) {
         // Eagerly destroying InjectableBusinessProcessContext is unsupported
-        // See https://jira.orqueio..com/browse/CAM-13755
+        // See https://jira.orqueio.com/browse/CAM-13755
       }
     });
 

--- a/quarkus-extension/engine/qa/src/test/resources/application.properties
+++ b/quarkus-extension/engine/qa/src/test/resources/application.properties
@@ -1,4 +1,4 @@
-# See https://jira.orqueio..com/browse/CAM-13748
+# See https://jira.orqueio.com/browse/CAM-13748
 quarkus.arc.auto-inject-fields=false
 
 quarkus.log.level=INFO
@@ -6,4 +6,4 @@ quarkus.log.category."io.orqueio".level=INFO
 
 quarkus.datasource.jdbc.url=jdbc:h2:mem:camunda.;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
 
-quarkus.orqueio..generic-config.enforce-history-time-to-live=false
+quarkus.orqueio.generic-config.enforce-history-time-to-live=false

--- a/quarkus-extension/engine/runtime/src/main/java/io/orqueio/bpm/quarkus/engine/extension/OrqueioEngineConfig.java
+++ b/quarkus-extension/engine/runtime/src/main/java/io/orqueio/bpm/quarkus/engine/extension/OrqueioEngineConfig.java
@@ -22,7 +22,7 @@ import io.smallrye.config.ConfigMapping;
 import java.util.Map;
 import java.util.Optional;
 
-@ConfigMapping(prefix = "quarkus.orqueio.")
+@ConfigMapping(prefix = "quarkus.orqueio")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface OrqueioEngineConfig {
 

--- a/quarkus-extension/engine/runtime/src/main/java/io/orqueio/bpm/quarkus/engine/extension/impl/OrqueioEngineRecorder.java
+++ b/quarkus-extension/engine/runtime/src/main/java/io/orqueio/bpm/quarkus/engine/extension/impl/OrqueioEngineRecorder.java
@@ -45,6 +45,16 @@ import org.eclipse.microprofile.context.ManagedExecutor;
 @Recorder
 public class OrqueioEngineRecorder {
 
+  private final RuntimeValue<OrqueioEngineConfig> configRuntimeValue;
+
+  public OrqueioEngineRecorder(RuntimeValue<OrqueioEngineConfig> configRuntimeValue) {
+    this.configRuntimeValue = configRuntimeValue;
+  }
+
+  private OrqueioEngineConfig config() {
+    return configRuntimeValue.getValue();
+  }
+
   public void configureProcessEngineCdiBeans(BeanContainer beanContainer) {
 
     if (BeanManagerLookup.localInstance == null) {
@@ -52,11 +62,12 @@ public class OrqueioEngineRecorder {
     }
   }
 
-  public RuntimeValue<ProcessEngineConfigurationImpl> createProcessEngineConfiguration(BeanContainer beanContainer,
-                                                                                       OrqueioEngineConfig config) {
+  public RuntimeValue<ProcessEngineConfigurationImpl> createProcessEngineConfiguration(BeanContainer beanContainer) {
 
     QuarkusProcessEngineConfiguration configuration = getBeanFromContainer(QuarkusProcessEngineConfiguration.class,
         beanContainer);
+
+    OrqueioEngineConfig config = config();
 
     // apply properties from config before any other configuration.
     PropertyHelper.applyProperties(configuration, config.genericConfig(), PropertyHelper.KEBAB_CASE);


### PR DESCRIPTION
Fixes [#166](https://github.com/OrqueIO/OrqueIO/issues/166).

Three rebrand/forward-compat defects in orqueio-bpm-quarkus-engine 2.0.5:

RUN_TIME config in a build step: processEngineConfiguration took OrqueioEngineConfig (@ConfigRoot(phase = RUN_TIME)) as a @BuildStep parameter. Newer Quarkus (observed on 3.32.x) rejects this; the extension boots on the pinned 3.27.0.CR1 but not on a current Quarkus. Now injected into OrqueioEngineRecorder via the constructor as RuntimeValue<OrqueioEngineConfig>: the canonical [Writing Extensions](https://quarkus.io/guides/writing-extensions) pattern.

Trailing-dot @ConfigMapping prefix: "quarkus.orqueio." yields the effective prefix quarkus.orqueio.., so canonical quarkus.orqueio.* keys are Unrecognized at boot. Dropped the trailing dot; README + test resources updated to single-dot.
Datasource stray-dot: the same rebrand named a test datasource orqueio., which Agroal can't resolve (No bean found @DataSource("orqueio.")). Renamed to orqueio; also fixed jira.orqueio..com -> jira.orqueio.com links to match the rest of the repo.

Testing: mvn -pl quarkus-extension/engine/runtime,quarkus-extension/engine/deployment -Pquarkus-tests test, against Quarkus 3.27.0.CR1. This turns two previously-failing tests green (OrqueioEngineConfigFileTest, OrqueioEngineProgrammaticAndConfigFileTest: datasource orqueio. was unresolvable). The remaining -Pquarkus-tests failures are pre-existing and unrelated (mangled BPMN namespace prefix in test .bpmn20.xml; a JMX MBean test-isolation conflict): they fail identically on clean v2.0.5 and are out of scope (noted as a follow-up in [#166](https://github.com/OrqueIO/OrqueIO/issues/166)).