### PR TITLE
fix(quarkus): bind camunda namespace prefix in test BPMN resources

### DIFF
--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/ManagedJobExecutorTest.shouldExecuteJob.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/ManagedJobExecutorTest.shouldExecuteJob.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda.="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0o4l4e4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Orqueio Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0o4l4e4" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Orqueio Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="asyncTaskProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1kyojiy</bpmn:outgoing>
@@ -9,7 +9,7 @@
       <bpmn:incoming>Flow_0ol67i5</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0ol67i5" sourceRef="Activity_1wnde44" targetRef="Event_0opmjta" />
-    <bpmn:serviceTask id="Activity_1wnde44" name="Async Task" orqueio.:asyncBefore="true" orqueio.:expression="${true}">
+    <bpmn:serviceTask id="Activity_1wnde44" name="Async Task" camunda:asyncBefore="true" camunda:expression="${true}">
       <bpmn:incoming>Flow_1kyojiy</bpmn:incoming>
       <bpmn:outgoing>Flow_0ol67i5</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/deployment/simpleServiceTaskProcess.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda.="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_144rplc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Orqueio Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_144rplc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Orqueio Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="simpleServiceTaskProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0kwqjvm</bpmn:outgoing>
@@ -9,7 +9,7 @@
       <bpmn:incoming>Flow_05ve86e</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_05ve86e" sourceRef="Activity_02p298y" targetRef="Event_0zpl8hb" />
-    <bpmn:serviceTask id="Activity_02p298y" name="Autocomplete Service Task" orqueio.:expression="${true}">
+    <bpmn:serviceTask id="Activity_02p298y" name="Autocomplete Service Task" camunda:expression="${true}">
       <bpmn:incoming>Flow_0kwqjvm</bpmn:incoming>
       <bpmn:outgoing>Flow_05ve86e</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldRollbackInServiceTask.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldRollbackInServiceTask.bpmn20.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda.="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.0-nightly">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.0-nightly">
   <bpmn:process id="txRollbackServiceTask" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1j3od4f</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_1j3od4f" sourceRef="StartEvent_1" targetRef="Task_0omi9wj" />
-    <bpmn:serviceTask id="Task_0omi9wj" name="failing transaction task" orqueio.:asyncBefore="true" orqueio.:delegateExpression="${transactionRollbackDelegate}">
+    <bpmn:serviceTask id="Task_0omi9wj" name="failing transaction task" camunda:asyncBefore="true" camunda:delegateExpression="${transactionRollbackDelegate}">
       <bpmn:incoming>SequenceFlow_1j3od4f</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0zpkb9t</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldRollbackInServiceTaskWithCustomRetryCycle.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldRollbackInServiceTaskWithCustomRetryCycle.bpmn20.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda.="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.0-nightly">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.0-nightly">
   <bpmn:process id="txRollbackServiceTaskWithCustomRetryCycle" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1j3od4f</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_1j3od4f" sourceRef="StartEvent_1" targetRef="Task_0omi9wj" />
-    <bpmn:serviceTask id="Task_0omi9wj" name="failing transaction task" orqueio.:asyncBefore="true" orqueio.:delegateExpression="${transactionRollbackDelegate}">
+    <bpmn:serviceTask id="Task_0omi9wj" name="failing transaction task" camunda:asyncBefore="true" camunda:delegateExpression="${transactionRollbackDelegate}">
       <bpmn:extensionElements>
-        <orqueio.:failedJobRetryTimeCycle>R5/PT0S</orqueio.:failedJobRetryTimeCycle>
+        <camunda:failedJobRetryTimeCycle>R5/PT0S</camunda:failedJobRetryTimeCycle>
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1j3od4f</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0zpkb9t</bpmn:outgoing>

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldRollbackOnException.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldRollbackOnException.bpmn20.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:camunda.="http://camunda.org/schema/1.0/bpmn"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
   targetNamespace="Examples">
   
   <process id="helloProcess" isExecutable="true">
@@ -12,7 +12,7 @@
     <userTask id="task" name="My Task" />
     <sequenceFlow id="flow2" sourceRef="task" targetRef="print" />
     
-    <serviceTask id="print"  orqueio.:expression="#{failing_expression}" />
+    <serviceTask id="print"  camunda:expression="#{failing_expression}" />
     <sequenceFlow id="flow3" sourceRef="print" targetRef="userTask" />
     
     <userTask id="userTask" />

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldRollbackOnExceptionInTransactionListener.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldRollbackOnExceptionInTransactionListener.bpmn20.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda.="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.0-nightly">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.2.0-nightly">
   <bpmn:process id="failingTransactionListener" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1j3od4f</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_1j3od4f" sourceRef="StartEvent_1" targetRef="Task_0omi9wj" />
-    <bpmn:serviceTask id="Task_0omi9wj" name="failing transaction listener task" orqueio.:asyncBefore="true" orqueio.:delegateExpression="${failingTransactionListenerDelegate}">
+    <bpmn:serviceTask id="Task_0omi9wj" name="failing transaction listener task" camunda:asyncBefore="true" camunda:delegateExpression="${failingTransactionListenerDelegate}">
       <bpmn:incoming>SequenceFlow_1j3od4f</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0zpkb9t</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldSucceed.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldSucceed.bpmn20.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-  xmlns:camunda.="http://camunda.org/schema/1.0/bpmn"
+  xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
   targetNamespace="Examples">
   
   <process id="helloProcess" isExecutable="true">
@@ -10,7 +10,7 @@
     <sequenceFlow id="flow1" sourceRef="start" targetRef="print" />
     
     <serviceTask id="print" 
-                 orqueio.:delegateExpression="${fooDelegate}" />
+                 camunda:delegateExpression="${fooDelegate}" />
     <sequenceFlow id="flow2" sourceRef="print" targetRef="userTask" />
     
     <userTask id="userTask" />

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldThrowException.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/TransactionIntegrationTest.shouldThrowException.bpmn20.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions id="definitions"
              xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
-             xmlns:camunda.="http://camunda.org/schema/1.0/bpmn"
+             xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
              targetNamespace="Examples">
 
   <process id="throwException" isExecutable="true">
@@ -11,8 +11,8 @@
     <subProcess id="sub" >
       <startEvent id="subStart" />
       <serviceTask id="servicetask"
-                   orqueio.:delegateExpression="#{serviceTaskBean}"
-                   orqueio.:async="true" />
+                   camunda:delegateExpression="#{serviceTaskBean}"
+                   camunda:async="true" />
       <endEvent id="subEnd" />
       <sequenceFlow sourceRef="subStart" targetRef="servicetask"/>
       <sequenceFlow sourceRef="servicetask" targetRef="subEnd"/>

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.shouldMarkAsRollbackOnly.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.shouldMarkAsRollbackOnly.bpmn20.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda.="http://camunda.org/schema/1.0/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples">
   <process id="testProcessFailure" isExecutable="true">
     <startEvent id="theStart" name="Start"></startEvent>
     <endEvent id="endevent1" name="End"></endEvent>
-    <serviceTask id="servicetask1" name="Service Task" orqueio.:delegateExpression="${failingDelegate}"></serviceTask>
+    <serviceTask id="servicetask1" name="Service Task" camunda:delegateExpression="${failingDelegate}"></serviceTask>
     <sequenceFlow id="flow11" name="" sourceRef="servicetask1" targetRef="endevent1"></sequenceFlow>
     <sequenceFlow id="flow12" name="" sourceRef="theStart" targetRef="servicetask1"></sequenceFlow>
   </process>

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.shouldNotStoreProcessInstance.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.shouldNotStoreProcessInstance.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda.="http://camunda.org/schema/1.0/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples">
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples">
   <process id="testApplicationFailure" isExecutable="true">
     <startEvent id="theStart" name="Start"></startEvent>
     <endEvent id="endevent1" name="End"></endEvent>

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.shouldSucceed.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/persistence/UserTransactionIntegrationTest.shouldSucceed.bpmn20.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:camunda.="http://camunda.org/schema/1.0/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" targetNamespace="Examples">
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" targetNamespace="Examples">
   <process id="testTxSuccess" isExecutable="true">
     <startEvent id="theStart" name="Start">
       <outgoing>flow12</outgoing>


### PR DESCRIPTION
Fixes [#168](https://github.com/OrqueIO/OrqueIO/issues/168).

11 `-Pquarkus-tests` BPMN files declare `xmlns:camunda.="http://camunda.org/schema/1.0/bpmn"` (a stray-dot prefix from the camunda->orqueio rebrand) but reference attributes/elements via `orqueio.:` - the prefix is unbound, so parsing fails (`ENGINE-09003`), which cascades into JMX MBean duplicate-registration errors (`ENGINE-08035`). Fixed by restoring a consistent `camunda` prefix bound to the unchanged, engine-recognized `camunda.org` URI (`xmlns:camunda.=` -> `xmlns:camunda=`, `orqueio.:` -> `camunda:`).

Testing: `mvn -pl quarkus-extension/engine/runtime,quarkus-extension/engine/deployment -Pquarkus-tests test` goes from 12 -> 2 errors, and the suite now runs 39 tests (was 29: parse failures previously aborted those classes at setup). The 2 remaining failures (`OrqueioEngineConfigFileTest` and `OrqueioEngineProgrammaticAndConfigFileTest`) are the datasource stray-dot fixed by [#167](https://github.com/OrqueIO/OrqueIO/issues/167); with both merged the suite is fully green.