### PR TITLE
fix(engine-cdi): resolve CDI bean expressions under CDI Lite (Quarkus)

### DIFF
--- a/engine-cdi/core/src/main/java/io/orqueio/bpm/engine/cdi/impl/el/CdiResolver.java
+++ b/engine-cdi/core/src/main/java/io/orqueio/bpm/engine/cdi/impl/el/CdiResolver.java
@@ -26,8 +26,23 @@ import io.orqueio.bpm.impl.juel.jakarta.el.ELResolver;
 
 
 /**
- * Resolver wrapping an instance of javax.el.ELResolver obtained from the
- * {@link BeanManager}. Allows the process engine to resolve Cdi-Beans.
+ * Resolves CDI beans referenced as the root of an EL expression, e.g. the
+ * {@code bean} in <code>${bean.method(execution)}</code>.
+ *
+ * <p>This resolver only resolves the <em>root</em> bean name, via
+ * {@link ProgrammaticBeanLookup} (which uses {@link BeanManager#getBeans} and is
+ * supported by every CDI container, including CDI Lite runtimes such as Quarkus
+ * ArC). It intentionally does <em>not</em> delegate to
+ * {@link BeanManager#getELResolver()}: that method is optional under CDI Lite,
+ * and Quarkus ArC throws {@link UnsupportedOperationException} for it, which
+ * previously made every {@code ${bean.method(...)}} expression fail at runtime
+ * under Quarkus. The delegation is also unnecessary: property access and method
+ * invocation on the resolved bean are handled by the {@code ArrayELResolver},
+ * {@code ListELResolver}, {@code MapELResolver} and {@code BeanELResolver} that
+ * {@code CdiExpressionManager} already adds to the resolver chain after this
+ * one. Dropping it is therefore behaviourally equivalent on a full CDI container
+ * (Weld already routed method invocation through a {@code BeanELResolver}) while
+ * also working under CDI Lite.
  *
  * @author Daniel Meyer
  */
@@ -37,58 +52,62 @@ public class CdiResolver extends ELResolver {
     return BeanManagerLookup.getBeanManager();
   }
 
-  protected javax.el.ELResolver getWrappedResolver() {
-    BeanManager beanManager = getBeanManager();
-    javax.el.ELResolver resolver = beanManager.getELResolver();
-    return resolver;
-  }
-
-  @Override
-  public Class< ? > getCommonPropertyType(ELContext context, Object base) {
-    return getWrappedResolver().getCommonPropertyType(wrapContext(context), base);
-  }
-
-  @Override
-  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
-    return getWrappedResolver().getFeatureDescriptors(wrapContext(context), base);
-  }
-
-  @Override
-  public Class< ? > getType(ELContext context, Object base, Object property) {
-    return getWrappedResolver().getType(wrapContext(context), base, property);
-  }
-
   @Override
   public Object getValue(ELContext context, Object base, Object property) {
     //we need to resolve a bean only for the first "member" of expression, e.g. bean.property1.property2
-    if (base == null) {
+    if (base == null && property != null) {
       Object result = ProgrammaticBeanLookup.lookup(property.toString(), getBeanManager());
       if (result != null) {
         context.setPropertyResolved(true);
       }
       return result;
-    } else {
-      return null;
     }
+    return null;
+  }
+
+  @Override
+  public Class< ? > getType(ELContext context, Object base, Object property) {
+    if (base == null && property != null) {
+      Object result = ProgrammaticBeanLookup.lookup(property.toString(), getBeanManager());
+      if (result != null) {
+        context.setPropertyResolved(true);
+        return result.getClass();
+      }
+    }
+    return null;
   }
 
   @Override
   public boolean isReadOnly(ELContext context, Object base, Object property) {
-    return getWrappedResolver().isReadOnly(wrapContext(context), base, property);
+    // a CDI bean resolved by name cannot be reassigned through that name
+    if (base == null && property != null
+        && ProgrammaticBeanLookup.lookup(property.toString(), getBeanManager()) != null) {
+      context.setPropertyResolved(true);
+      return true;
+    }
+    return false;
   }
 
   @Override
   public void setValue(ELContext context, Object base, Object property, Object value) {
-    getWrappedResolver().setValue(wrapContext(context), base, property, value);
+    // assigning to a CDI bean root is not supported; left to the rest of the chain
   }
 
   @Override
   public Object invoke(ELContext context, Object base, Object method, java.lang.Class< ? >[] paramTypes, Object[] params) {
-    return getWrappedResolver().invoke(wrapContext(context), base, method, paramTypes, params);
+    // method invocation happens on the already-resolved base and is handled by the
+    // BeanELResolver further down the CdiExpressionManager chain
+    return null;
   }
 
-  protected javax.el.ELContext wrapContext(ELContext context) {
-    return new ElContextDelegate(context, getWrappedResolver());
+  @Override
+  public Class< ? > getCommonPropertyType(ELContext context, Object base) {
+    return base == null ? Object.class : null;
+  }
+
+  @Override
+  public Iterator<FeatureDescriptor> getFeatureDescriptors(ELContext context, Object base) {
+    return null;
   }
 
 }

--- a/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/el/CdiExpressionResolutionTest.java
+++ b/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/el/CdiExpressionResolutionTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OrqueIO contributors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.orqueio.bpm.quarkus.engine.test.el;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.QuarkusUnitTest;
+import io.orqueio.bpm.engine.ProcessEngine;
+import io.orqueio.bpm.engine.RuntimeService;
+import io.orqueio.bpm.engine.runtime.ProcessInstance;
+import io.orqueio.bpm.engine.test.Deployment;
+import io.orqueio.bpm.quarkus.engine.test.helper.ProcessEngineAwareExtension;
+import jakarta.inject.Inject;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Verifies that a BPMN {@code camunda:expression} which invokes a method on a
+ * {@code @Named} CDI bean resolves under Quarkus ArC.
+ *
+ * <p>Before the {@code CdiResolver} fix this failed with
+ * {@code UnsupportedOperationException} from {@code BeanManagerImpl.getELResolver()},
+ * because ArC (CDI Lite) does not implement that optional method.</p>
+ */
+public class CdiExpressionResolutionTest {
+
+  @RegisterExtension
+  static final QuarkusUnitTest unitTest = new ProcessEngineAwareExtension()
+      .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+          .addClass(GreetingBean.class));
+
+  @Inject
+  ProcessEngine processEngine;
+
+  @Test
+  @Deployment(resources = "io/orqueio/bpm/quarkus/engine/test/el/cdi-expression-process.bpmn20.xml")
+  public void shouldInvokeCdiBeanMethodFromExpression() {
+    // given a process whose service task is camunda:expression="${greetingBean.greet(execution)}"
+    RuntimeService runtimeService = processEngine.getRuntimeService();
+
+    // when the process is started (the service task runs synchronously)
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("cdiExpressionProcess");
+
+    // then the CDI bean method was invoked and set the variable
+    assertThat(runtimeService.getVariable(processInstance.getId(), "greeting"))
+        .isEqualTo("Hello from CDI");
+  }
+}

--- a/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/el/GreetingBean.java
+++ b/quarkus-extension/engine/deployment/src/test/java/io/orqueio/bpm/quarkus/engine/test/el/GreetingBean.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OrqueIO contributors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.orqueio.bpm.quarkus.engine.test.el;
+
+import io.orqueio.bpm.engine.delegate.DelegateExecution;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+
+/**
+ * A {@code @Named} CDI bean whose method is invoked from a BPMN
+ * {@code camunda:expression="${greetingBean.greet(execution)}"}. Exercises the
+ * EL method-invocation path through {@code CdiResolver} under Quarkus ArC.
+ */
+@Named("greetingBean")
+@ApplicationScoped
+public class GreetingBean {
+
+  public void greet(DelegateExecution execution) {
+    execution.setVariable("greeting", "Hello from CDI");
+  }
+}

--- a/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/el/cdi-expression-process.bpmn20.xml
+++ b/quarkus-extension/engine/deployment/src/test/resources/io/orqueio/bpm/quarkus/engine/test/el/cdi-expression-process.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:camunda="http://camunda.org/schema/1.0/bpmn"
+             targetNamespace="http://orqueio.io/test"
+             id="cdiExpressionDefinitions">
+  <process id="cdiExpressionProcess" isExecutable="true">
+    <startEvent id="start"/>
+    <sequenceFlow id="flowStartToInvoke" sourceRef="start" targetRef="invokeBean"/>
+    <serviceTask id="invokeBean" camunda:expression="${greetingBean.greet(execution)}"/>
+    <sequenceFlow id="flowInvokeToWait" sourceRef="invokeBean" targetRef="wait"/>
+    <userTask id="wait"/>
+    <sequenceFlow id="flowWaitToEnd" sourceRef="wait" targetRef="end"/>
+    <endEvent id="end"/>
+  </process>
+</definitions>


### PR DESCRIPTION
Fixes [#170](https://github.com/OrqueIO/OrqueIO/issues/170).

`camunda:expression="${bean.method(execution)}"` fails under Quarkus because `CdiResolver` delegates method invocation to `BeanManager.getELResolver()`, which ArC (CDI Lite) doesn't implement (`UnsupportedOperationException`). `getValue()` already resolved the root bean via `ProgrammaticBeanLookup`; the other six methods delegated unnecessarily, since `CdiExpressionManager`'s chain already has `Array/List/Map/BeanELResolver` to handle access/invocation on the resolved bean. This makes `CdiResolver` resolve only the root bean name and stay out of the way otherwise — equivalent under Weld, working under CDI Lite. (`ElContextDelegate` becomes unused; left in place to avoid touching public API.)

**Testing:** existing engine-cdi Weld EL tests (`ElTest`, `BeanPropertyElTest`, `TaskListenerInvocationTest`) pass; a new ArC test `CdiExpressionResolutionTest` (a `@Named` bean invoked from a `camunda:expression`) passes against the patched module and fails without the fix.